### PR TITLE
detect path correctly even when `expand('%')` is a relative path

### DIFF
--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -20,6 +20,7 @@ function! nvimdev#init(path) abort
   endif
 
   let g:nvimdev_loaded = 2
+  let g:nvimdev_root = a:path
   let s:path = a:path
   let s:errors_root = s:path . '/tmp/errors'
 

--- a/plugin/nvimdev.vim
+++ b/plugin/nvimdev.vim
@@ -13,7 +13,7 @@ function! s:check_nvim() abort
   " It's a pretty unique filename and it sounds cool, like 'shadow cat'.
   let file_hint = '/scripts/shadacat.py'
   let last_path = expand('%')
-  let path = fnamemodify(last_path, ':h')
+  let path = fnamemodify(last_path, ':p:h')
 
   let found = ''
   while path != last_path


### PR DESCRIPTION
The path will become incorrect if one uses `:cd` after starting nvim. Seems safest to always use absolute path.

also add `g:nvimdev_root` to be able to quickly access root in user config.