### PR TITLE
clint maker: use output_stream=stdout

### DIFF
--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -68,6 +68,7 @@ function! nvimdev#init(path) abort
         \ 'cwd': s:path,
         \ 'errorformat': '%-GTotal errors%.%#,%f:%l: %m',
         \ 'remove_invalid_entries': get(g:, 'neomake_remove_invalid_entries', 0),
+        \ 'output_stream': 'stdout',
         \ }
 
   function linter.InitForJob(jobinfo) abort


### PR DESCRIPTION
This allows Neomake to report unexpected output, e.g. a Python traceback
in case of errors.