### PR TITLE
Disable g:nvimdev_auto_ctags by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It should always be set to the actual Neovim root.
 
 Automatically `:cd` to the Neovim root after init.
 
-#### `g:nvimdev_auto_ctags` (default `1`)
+#### `g:nvimdev_auto_ctags` (default `0`)
 
 Automatically generate tags.
 

--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -140,7 +140,7 @@ function! nvimdev#init(path) abort
   augroup nvimdev
     autocmd!
     autocmd BufRead,BufNewFile *.h set filetype=c
-    if get(g:, 'nvimdev_auto_ctags', 1) || get(g:, 'nvimdev_auto_cscope', 0)
+    if get(g:, 'nvimdev_auto_ctags', 0) || get(g:, 'nvimdev_auto_cscope', 0)
       autocmd BufWritePost *.c,*.h,*.lua call s:build_db()
     endif
     if get(g:, 'nvimdev_build_readonly', 1)


### PR DESCRIPTION
I was wondering what was messing with my `tags` file, where Lua tags
from below `test/` were missing.

It should include "test" when generating tags probably, but even then it
is not nice to mess with `tags` files by default (which users might
manage already when switching branches automatically etc).
Also it is quite some overhead in general to trigger that on every save.