### PR TITLE
Set readonly/nomodifiable only once

### DIFF
--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -8,6 +8,13 @@ let s:include_paths = [
       \ ]
 
 
+function! s:set_readonly() abort
+  if !exists('b:_nvimdev_set_readonly')
+    let b:_nvimdev_set_readonly = 1
+    setlocal readonly nomodifiable
+  endif
+endfunction
+
 function! nvimdev#init(path) abort
   let g:nvimdev_loaded = 2
   let g:nvimdev_root = a:path
@@ -49,10 +56,14 @@ function! nvimdev#init(path) abort
       autocmd BufWritePost *.c,*.h,*.lua call s:build_db()
     endif
     if get(g:, 'nvimdev_build_readonly', 1)
-      execute 'autocmd BufRead ' . s:path . '/build/* setlocal readonly nomodifiable'
-      execute 'autocmd BufRead ' . s:path . '/.deps/* setlocal readonly nomodifiable'
+      execute 'autocmd BufEnter '.fnameescape(s:path).'/{build,.deps}/* call s:set_readonly()'
     endif
   augroup END
+
+  " Init for first buffer, since this is called on BufEnter itself.
+  if exists('#nvimdev#BufEnter')
+    doautocmd nvimdev BufEnter
+  endif
 
   call nvimdev#update_clint_errors()
 endfunction

--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -8,13 +8,6 @@ let s:include_paths = [
       \ ]
 
 
-function! s:set_readonly() abort
-  if !exists('b:_nvimdev_set_readonly')
-    let b:_nvimdev_set_readonly = 1
-    setlocal readonly nomodifiable
-  endif
-endfunction
-
 function! nvimdev#init(path) abort
   let g:nvimdev_loaded = 2
   let g:nvimdev_root = a:path
@@ -49,6 +42,8 @@ function! nvimdev#init(path) abort
     endif
   endif
 
+  let do_bufenter = 0
+
   augroup nvimdev
     autocmd!
     autocmd BufRead,BufNewFile *.h set filetype=c
@@ -56,12 +51,18 @@ function! nvimdev#init(path) abort
       autocmd BufWritePost *.c,*.h,*.lua call s:build_db()
     endif
     if get(g:, 'nvimdev_build_readonly', 1)
-      execute 'autocmd BufEnter '.fnameescape(s:path).'/{build,.deps}/* call s:set_readonly()'
+      let glob = fnameescape(s:path).'/{build,.deps}/*'
+      execute 'autocmd BufEnter '.glob.' '
+            \ .(has('nvim-0.4.0') ? '++once ' : '')
+            \ .'setlocal readonly nomodifiable'
+      if expand('%:p') =~# glob2regpat(glob)
+        let do_bufenter = 1
+      endif
     endif
   augroup END
 
   " Init for first buffer, since this is called on BufEnter itself.
-  if exists('#nvimdev#BufEnter')
+  if do_bufenter
     doautocmd nvimdev BufEnter
   endif
 

--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -50,20 +50,20 @@ function! nvimdev#init(path) abort
     endif
     if get(g:, 'nvimdev_build_readonly', 1)
       if has('nvim-0.4.0')
-        execute 'autocmd BufEnter '.fnameescape(s:path).'/{build,.deps}/* '
+        execute 'autocmd BufRead '.fnameescape(s:path).'/{build,.deps}/* '
               \ .'au CursorMoved <buffer> ++once setlocal readonly nomodifiable'
       else
-        execute 'autocmd BufEnter '.fnameescape(s:path).'/{build,.deps}/* '
+        execute 'autocmd BufRead '.fnameescape(s:path).'/{build,.deps}/* '
               \ .'setlocal readonly nomodifiable'
       endif
     endif
 
     " Dummy event to avoid "No matching autocommands" below.
-    autocmd BufEnter <buffer> au! nvimdev BufEnter <buffer>
+    autocmd BufRead <buffer> au! nvimdev BufRead <buffer>
   augroup END
 
   " Init for first buffer, since this is called on BufEnter itself.
-  doautocmd nvimdev BufEnter
+  doautocmd nvimdev BufRead
 
   call nvimdev#update_clint_errors()
 endfunction

--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -58,8 +58,11 @@ function! nvimdev#init(path) abort
       endif
     endif
 
-    " Dummy event to avoid "No matching autocommands" below.
-    autocmd BufRead <buffer> au! nvimdev BufRead <buffer>
+    if !has('nvim-0.4.0')
+      " Dummy event to avoid "No matching autocommands" below.
+      " Not required with neovim/neovim@45c34bd.
+      autocmd BufRead <buffer> au! nvimdev BufRead <buffer>
+    endif
   augroup END
 
   " Init for first buffer, since this is called on BufEnter itself.


### PR DESCRIPTION
While it can be helpful in general, it should not get into your way
after "set modifiable", and the buffer being reloaded.

I've also thought about only using "readonly", but skipped that for now.